### PR TITLE
Disabled TLS 1.0/1.1 by default. Cleaned up usage of Java -D args…

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:10-jre-slim
 
-ARG DEFAULT_JAVA_OPTIONS="-Xmx300M -server -Djava.security.egd=file:/dev/./urandom -Djavax.net.ssl.trustStore=\${JAVA_TRUSTSTORE} -Djavax.net.ssl.trustStorePassword=\${JAVA_TRUSTSTORE_PASS}"
+ARG DEFAULT_JAVA_OPTIONS="-Xmx300M -server"
 
 LABEL maintainer="gs-w_eto_eb_federal_employees@usgs.gov"
 
@@ -36,6 +36,7 @@ WORKDIR $HOME
 COPY --chown=1000:1000 pull-from-artifactory.sh pull-from-artifactory.sh
 COPY --chown=1000:1000 entrypoint.sh entrypoint.sh
 COPY --chown=1000:1000 launch-app.sh $LAUNCH_APP_SCRIPT
+COPY --chown=1000:1000 java.security.properties java.security.properties
 RUN chmod +x pull-from-artifactory.sh entrypoint.sh $LAUNCH_APP_SCRIPT
 USER $USER
 

--- a/10/entrypoint.sh
+++ b/10/entrypoint.sh
@@ -54,7 +54,7 @@ fi
 # since the environment variables they reference aren't defined until further down in
 # the Dockerfile. Thus we need to evalute those escaped environment references now.
 if [ -z "$JAVA_OPTIONS" ]; then
-    JAVA_OPTIONS="-server -Djava.security.egd=file:/dev/./urandom"
+    JAVA_OPTIONS="-server"
 else
     echo "Evaluating Java run options: $JAVA_OPTIONS"
     JAVA_OPTIONS=$(eval echo $JAVA_OPTIONS)

--- a/10/java.security.properties
+++ b/10/java.security.properties
@@ -1,0 +1,3 @@
+jdk.tls.disabledAlgorithms=SSLv3, RC4, MD5withRSA, DH keySize < 1024, \
+    EC keySize < 224, DES40_CBC, RC4_40, 3DES_EDE_CBC, TLSv1, TLSv1.1, \
+    SSLv2Hello

--- a/10/launch-app.sh
+++ b/10/launch-app.sh
@@ -3,9 +3,9 @@
 echo "Using default /launch-app.sh.."
 
 if [ -f "$HOME/app.jar" ]; then
-    java $JAVA_OPTIONS -jar $HOME/app.jar "$@"
+    java $JAVA_OPTIONS -Djava.security.egd=file:/dev/./urandom -Djava.security.properties=${HOME}/java.security.properties -jar $HOME/app.jar "$@"
 elif [ -f "$HOME/app.war" ]; then
-    java $JAVA_OPTIONS -jar $HOME/app.war "$@"
+    java $JAVA_OPTIONS -Djava.security.egd=file:/dev/./urandom -Djava.security.properties=${HOME}/java.security.properties -jar $HOME/app.war "$@"
 else
     echo "No $HOME/app.jar and no $HOME/app.war found. Exiting."
     exit 1

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre-slim
 
-ARG DEFAULT_JAVA_OPTIONS="-Xmx300M -server -Djava.security.egd=file:/dev/./urandom -Djavax.net.ssl.trustStore=\${JAVA_TRUSTSTORE} -Djavax.net.ssl.trustStorePassword=\${JAVA_TRUSTSTORE_PASS}"
+ARG DEFAULT_JAVA_OPTIONS="-Xmx300M -server"
 
 LABEL maintainer="gs-w_eto_eb_federal_employees@usgs.gov"
 
@@ -36,6 +36,7 @@ WORKDIR $HOME
 COPY --chown=1000:1000 pull-from-artifactory.sh pull-from-artifactory.sh
 COPY --chown=1000:1000 entrypoint.sh entrypoint.sh
 COPY --chown=1000:1000 launch-app.sh $LAUNCH_APP_SCRIPT
+COPY --chown=1000:1000 java.security.properties java.security.properties
 RUN chmod +x pull-from-artifactory.sh entrypoint.sh $LAUNCH_APP_SCRIPT
 USER $USER
 

--- a/8/entrypoint.sh
+++ b/8/entrypoint.sh
@@ -54,7 +54,7 @@ fi
 # since the environment variables they reference aren't defined until further down in
 # the Dockerfile. Thus we need to evalute those escaped environment references now.
 if [ -z "$JAVA_OPTIONS" ]; then
-    JAVA_OPTIONS="-server -Djava.security.egd=file:/dev/./urandom"
+    JAVA_OPTIONS="-server"
 else
     echo "Evaluating Java run options: $JAVA_OPTIONS"
     JAVA_OPTIONS=$(eval echo $JAVA_OPTIONS)

--- a/8/java.security.properties
+++ b/8/java.security.properties
@@ -1,0 +1,3 @@
+jdk.tls.disabledAlgorithms=SSLv3, RC4, MD5withRSA, DH keySize < 1024, \
+    EC keySize < 224, DES40_CBC, RC4_40, 3DES_EDE_CBC, TLSv1, TLSv1.1, \
+    SSLv2Hello

--- a/8/launch-app.sh
+++ b/8/launch-app.sh
@@ -3,9 +3,9 @@
 echo "Using default /launch-app.sh.."
 
 if [ -f "$HOME/app.jar" ]; then
-    java $JAVA_OPTIONS -jar $HOME/app.jar "$@"
+    java $JAVA_OPTIONS -Djava.security.egd=file:/dev/./urandom -Djava.security.properties=${HOME}/java.security.properties -Djavax.net.ssl.trustStore=${JAVA_TRUSTSTORE} -Djavax.net.ssl.trustStorePassword=${JAVA_TRUSTSTORE_PASS} -jar $HOME/app.jar "$@"
 elif [ -f "$HOME/app.war" ]; then
-    java $JAVA_OPTIONS -jar $HOME/app.war "$@"
+    java $JAVA_OPTIONS -Djava.security.egd=file:/dev/./urandom -Djava.security.properties=${HOME}/java.security.properties -Djavax.net.ssl.trustStore=${JAVA_TRUSTSTORE} -Djavax.net.ssl.trustStorePassword=${JAVA_TRUSTSTORE_PASS} -jar $HOME/app.war "$@"
 else
     echo "No $HOME/app.jar and no $HOME/app.war found. Exiting."
     exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,6 @@
     10-jre-slim:
       build:
         context: ./10
-        args:
-          DEFAULT_JAVA_OPTIONS: "-Xmx300M -server -Djava.security.egd=file:/dev/./urandom"
       image: wma-spring-boot-base:10-jre-slim-latest
       << : *default-config
 


### PR DESCRIPTION
…Cleaned up JRE 10 image build.

Note that these changes will mean child images that are overriding `$JAVA_OPTIONS` should no longer include the following properties in their override value:

```
-Djava.security.egd=file:/dev/./urandom 
-Djavax.net.ssl.trustStore=${JAVA_TRUSTSTORE} -Djavax.net.ssl.trustStorePassword=${JAVA_TRUSTSTORE_PASS}
```
Note that the JRE 10 version of the image does not have the trustStore related -D args. This is because we still haven't figured out why these args are causing issues with Java 10. Prior to this PR we were avoiding the JRE 10 image hitting an error by overriding the JAVA_OPTIONS in the compose file. Now that we're using separate Dockerfiles and scripts for each Java version I just removed those args from the Java 10 version of the Dockerfile and scripts altogether.