### PR TITLE
Enabled maven dependency caching

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -2,7 +2,11 @@ FROM maven:3-jdk-10-slim AS build
 
 WORKDIR /build
 
+#copy pom if it has changed
 COPY pom.xml pom.xml
+
+#download all maven dependencies (this will only re-run if the pom has changed)
+RUN mvn -B dependency:go-offline
 
 COPY src /build/src
 

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -2,7 +2,11 @@ FROM maven:3-jdk-11-slim AS build
 
 WORKDIR /build
 
+#copy pom if it has changed
 COPY pom.xml pom.xml
+
+#download all maven dependencies (this will only re-run if the pom has changed)
+RUN mvn -B dependency:go-offline
 
 COPY src /build/src
 

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -2,13 +2,17 @@ FROM maven:3.6.0-jdk-8-alpine AS build
 
 WORKDIR /build
 
+#copy pom if it has changed
 COPY pom.xml pom.xml
+
+#download all maven dependencies (this will only re-run if the pom has changed)
+RUN mvn -B dependency:go-offline
 
 COPY src /build/src
 
 COPY .git .git
 
-RUN mvn clean package
+RUN mvn -B clean package
 
 FROM openjdk:8-jre-slim
 


### PR DESCRIPTION
I'm hoping to reduce the time it takes to test changes in this repo by caching one of the most time-consuming steps - the maven dependency downloads.