### PR TITLE
Updated the artifact_version to use an ARG isntead of an ENV to prevent…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 **/certificates/intermediate1/
 **/certificates/root/
 **/certificates/tomcat-wildcard.*
+/target/**
+.classpath
+.project
+.vscode/**
+.settings/**

--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -20,7 +20,7 @@ ARG DEFAULT_JAVA_OPTIONS="-Xmx300M -server"
 
 LABEL maintainer="gs-w_eto_eb_federal_employees@usgs.gov"
 
-ENV artifact_version=0.0.1-SNAPSHOT
+ARG artifact_version="set_the_artifact_version_arg_in_your_dockerfile"
 
 ENV USER=spring
 ENV HOME=/home/$USER

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -20,7 +20,7 @@ ARG DEFAULT_JAVA_OPTIONS="-Xmx300M -server"
 
 LABEL maintainer="gs-w_eto_eb_federal_employees@usgs.gov"
 
-ARG artifact_version=set_the_build_number_in_your_dockerfile
+ARG artifact_version="set_the_artifact_version_arg_in_your_dockerfile"
 
 ENV USER=spring
 ENV HOME=/home/$USER

--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -20,7 +20,7 @@ ARG DEFAULT_JAVA_OPTIONS="-Xmx300M -server"
 
 LABEL maintainer="gs-w_eto_eb_federal_employees@usgs.gov"
 
-ENV artifact_version=0.0.1-SNAPSHOT
+ARG artifact_version=set_the_build_number_in_your_dockerfile
 
 ENV USER=spring
 ENV HOME=/home/$USER

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -20,7 +20,7 @@ ARG DEFAULT_JAVA_OPTIONS="-Xmx300M -server"
 
 LABEL maintainer="gs-w_eto_eb_federal_employees@usgs.gov"
 
-ENV artifact_version=0.0.1-SNAPSHOT
+ARG artifact_version="set_the_artifact_version_arg_in_your_dockerfile"
 
 ENV USER=spring
 ENV HOME=/home/$USER

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ When launching your docker container you can specify files and directories to mo
 ### Extending the Base Image
 This docker image is not intended to be run on its own, rather other images should inherit from this image in order to utilize its functionality. 
 
+### Pulling down your application
+The recommended way to manage the version of the executable artifact running within the container is to define the version to be run as a build argument. This allows you to link a specific version of the Dockerfile with a specific version of the executable. The Dockerfiles for this image define an example build argument, `artifact_Version` to be used for this purpose. When building a downstream image you can override the value of this ARG with the proper version for your application and then pull it from Artifatory with the included `pull-from-artifactory.sh` script, or pull it from another source.
+
 #### The Entrypoint Script
 This docker image includes an entrypoint script that configures the keystore properly in order for your application to serve SSL certificates. Additionally, this entrypoint allows for your application to be launched via an additional script (detailed in the next section) if you need to run it with specific arguments or additional configuration. This entrypoint script is added to the docker image as `/entrypoint.sh`. 
 


### PR DESCRIPTION
… it from overriding the value set by downstream images if they use an ARG instead of an ENV (which is what we should be using anyways).