### PR TITLE
Release Prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Removed
+
+- cschroedl@usgs.gov - Removed custom environment variable names in favor of existing environment variable names recognized by Spring Boot.
+    | Old Custom Variable Name | New Spring Boot Variable Name |
+    |--------------------------|-------------------------------|
+    | requireSsl               | SECURITY_REQUIRESSL           |
+    | serverPort               | SERVER_PORT                   |
+    | keystoreLocation         | SERVER_SSL_KEYSTORE           |
+    | keystorePassword         | SERVER_SSL_KEYSTOREPASSWORD   |
+    | keystoreSSLKey           | SERVER_SSL_KEYALIAS           |
+
+## Changed
+
+- zmoore@usgs.gov - Changed `artifact_version` in all `Dockerfile`s  from an `ENV` to an `ARG` to prevent the parent from overriding the value set by downstream images if they use an `ARG` instead of an `ENV`.
+
 ## [0.0.4] - 2019-03-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Removed
 
 - cschroedl@usgs.gov - Removed custom environment variable names in favor of existing environment variable names recognized by Spring Boot.
+
     | Old Custom Variable Name | New Spring Boot Variable Name |
     |--------------------------|-------------------------------|
     | requireSsl               | SECURITY_REQUIRESSL           |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.0] - 2019-04-03
+
 ## Removed
 
 - cschroedl@usgs.gov - Removed custom environment variable names in favor of existing environment variable names recognized by Spring Boot.
@@ -99,7 +101,8 @@ downstream container start orchestration
 - isutftin@usgs.gov - Shell script linting
 - isuftin@usgs.gov - entrypoint script properly copying and appending keystore
 
-[Unreleased]: https://github.com/USGS-CIDA/docker-wma-spring-boot-base/compare/0.0.4...master
+[Unreleased]: https://github.com/USGS-CIDA/docker-wma-spring-boot-base/compare/1.0.0...master
+[1.0.0]: https://github.com/USGS-CIDA/docker-wma-spring-boot-base/compare/0.0.4...1.0.0
 [0.0.4]: https://github.com/USGS-CIDA/docker-wma-spring-boot-base/compare/0.0.3...0.0.4
 [0.0.3]: https://github.com/USGS-CIDA/docker-wma-spring-boot-base/compare/0.0.2...0.0.3
 [0.0.2]: https://github.com/USGS-CIDA/docker-wma-spring-boot-base/compare/0.0.1...0.0.2


### PR DESCRIPTION
Wes and I verified that the spring boot base image in master works in the context of DECAP, which is leveraging native Spring Boot env variables to simplify configuration. Naturally DECAP wants to rely on a release rather than a moving target :) but these recently-merged changes may break backwards compatibility for other projects. semver.org's guidance is...

> How do I know when to release 1.0.0?
> If your software is being used in production, it should probably already be 1.0.0. If you have a stable API on which users have come to depend, you should be 1.0.0. If you’re worrying a lot about backwards compatibility, you should probably already be 1.0.0.

https://semver.org/#how-do-i-know-when-to-release-100

With that in mind I'm proposing we release version 1.0.0. However, I think semver's FAQ could also be reasonably interpreted as a recommendation to release a version 1.0.0 *before* we make a release with breaking changes. If you would like to see a different version number on this release, please shout it out! (I'm a fan of 42)